### PR TITLE
if imagestore is not a dir, it will try to create it

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -1,5 +1,6 @@
 use std::error::Error;
 use std::path::PathBuf;
+use std::path::Path;
 
 use slurm_spank::SpankHandle;
 
@@ -76,6 +77,14 @@ pub(crate) fn setup_config(
     if config.parallax_imagestore == "" {
         plugin.config.skybox_enabled = false;
         return plugin_err("cannot find parallax_imagestore");
+    } else {
+        let store = &config.parallax_imagestore;
+        if !Path::new(store).exists() { // If imagestore does not exist, it tries to create it
+            if let Err(e) = std::fs::create_dir_all(store) {
+                plugin.config.skybox_enabled = false;
+                return plugin_err(&format!("cannot create parallax_imagestore: {e}"));
+            }
+        }
     }
 
     if config.parallax_mount_program == "" {


### PR DESCRIPTION
I think it makes sense that we validate the configs as soon as we pick them. That helps us fail quick.