### PR TITLE
VCUE-1439 Align profile handling with Container Engine expectations

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -123,7 +123,7 @@ pub(crate) fn setup_config(
         return plugin_err("cannot find podman_tmp_path");
     }
 
-    if config.tracking_tool == "" {
+    if config.tracking_enabled && config.tracking_tool == "" {
         plugin.config.tracking_enabled = false;
         return plugin_err("cannot find tracking_tool");
     }

--- a/src/container.rs
+++ b/src/container.rs
@@ -226,6 +226,17 @@ pub(crate) fn container_import_env(
     for (key, value) in edf_env.iter() {
         if value == "" {
             unset_keys.push(key);
+            continue;
+        }
+        let overwrite = true;
+
+        match spank.setenv(key, value, overwrite) {
+            Ok(ok) => ok,
+            Err(SpankError::EnvExists(_)) => (),
+            Err(e) => {
+                skybox_log_error!("couldn't set env {key}={value}: {e}");
+                return Err(Box::new(e));
+            }
         }
     }
 

--- a/src/podman.rs
+++ b/src/podman.rs
@@ -142,13 +142,14 @@ pub(crate) fn podman_start(
     let runroot = format!("{}/runroot", run.podman_tmp_path);
     let pidfile = format!("{}/pidfile", run.podman_tmp_path);
     //let command = vec!["sleep", "infinity"];
-    let command = vec!["sh", "-c", "kill -STOP $$ ; exit 0"];
+    //let command = vec!["sh", "-c", "kill -STOP $$ ; exit 0"];
+    let command = vec!["sh", "-l", "-c", "exec sh -c 'kill -STOP $$ ; exit 0'"];
 
     let c_ctx = ContainerCtx {
         name: run.name.clone(),
         interactive: false,
         detach: true,
-        set_env: true,
+        set_env: false,
         pidfile: Some(PathBuf::from(pidfile.clone())),
     };
 


### PR DESCRIPTION
* skybox : EDF environment variables are not loaded by podman command line on skybox, but later from /proc/${pid}/environ
* skybox : podman shim has changed to include profile variables in /proc/${pid}/environ
* podman-driver : set_env flag allows to exclude environment variable from command line

